### PR TITLE
Handle empty string checks in utility helpers

### DIFF
--- a/lameg/util.py
+++ b/lameg/util.py
@@ -348,26 +348,30 @@ def ctf_fif_spm_conversion(mne_file, res4_file, output_path, epoched, prefix="sp
 
 
 def check_many(multiple, target, func=None):
-    """
-    Check for the presence of strings in a target string.
+    """Check for the presence of strings in a target string.
 
     Parameters
     ----------
     multiple : list
-        List of strings to be found in the target string.
+        List of strings to be found in the target string. If ``multiple`` is ``None`` or
+        empty, the function returns ``True`` regardless of ``func``.
     target : str
         The target string in which to search for the specified strings.
     func : str
-        Specifies the search mode: "all" to check if all strings are present, or "any" to check if
-        any string is present.
+        Specifies the search mode: "all" to check if all strings are present, or "any" to check
+        if any string is present.
 
     Notes
     -----
-    - This function works well with `if` statements in list comprehensions.
+    - This function works well with ``if`` statements in list comprehensions.
     """
 
+    if not multiple:
+        return True
+
     func_dict = {
-        "all": all, "any": any
+        "all": all,
+        "any": any,
     }
     if func in func_dict:
         use_func = func_dict[func]
@@ -379,7 +383,7 @@ def check_many(multiple, target, func=None):
     return use_func(check_)
 
 
-def get_files(target_path, suffix, strings=(""), prefix=None, check="all", depth="all"):
+def get_files(target_path, suffix, strings=None, prefix=None, check="all", depth="all"):
     """
     Return a list of files with a specific extension, prefix, and name containing specific strings.
 
@@ -391,8 +395,9 @@ def get_files(target_path, suffix, strings=(""), prefix=None, check="all", depth
         The most shallow searched directory.
     suffix : str
         File extension in "\*.ext" format.
-    strings : list of str
-        List of strings to search for in the file name.
+    strings : list of str, optional
+        List of strings to search for in the file name. If ``None`` no string filtering is
+        applied.
     prefix : str
         Limits the output list to file names starting with this prefix.
     check : str
@@ -409,6 +414,8 @@ def get_files(target_path, suffix, strings=(""), prefix=None, check="all", depth
 
     path = Path(target_path)
     files = []
+    if strings is None:
+        strings = []
     if depth == "all":
         files = [file for file in path.rglob(suffix)
                  if file.is_file() and file.suffix == suffix[1:] and
@@ -424,7 +431,7 @@ def get_files(target_path, suffix, strings=(""), prefix=None, check="all", depth
     return files
 
 
-def get_directories(target_path, strings=(""), check="all", depth="all"):
+def get_directories(target_path, strings=None, check="all", depth="all"):
     """
     Return a list of directories in the path (or all subdirectories) containing specified strings.
 
@@ -443,6 +450,8 @@ def get_directories(target_path, strings=(""), check="all", depth="all"):
 
     path = Path(target_path)
     subdirs = []
+    if strings is None:
+        strings = []
     if depth == "all":
         subdirs = [subdir for subdir in path.glob("**/")
                    if subdir.is_dir() and check_many(strings, str(subdir), check)]

--- a/test_check_many.py
+++ b/test_check_many.py
@@ -1,0 +1,54 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+# Create lightweight stubs for optional heavy dependencies used in util.py
+sys.modules.setdefault("mne", types.ModuleType("mne"))
+sys.modules.setdefault("mne.coreg", types.ModuleType("mne.coreg"))
+sys.modules["mne.coreg"].Coregistration = object
+sys.modules.setdefault("mne.io", types.ModuleType("mne.io"))
+sys.modules["mne.io"]._empty_info = lambda: None
+sys.modules.setdefault("mne.transforms", types.ModuleType("mne.transforms"))
+sys.modules["mne.transforms"].apply_trans = lambda *a, **k: None
+sys.modules["mne.transforms"].invert_transform = lambda *a, **k: None
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+sys.modules.setdefault("h5py", types.ModuleType("h5py"))
+sys.modules["h5py"].File = lambda *a, **k: (_ for _ in ()).throw(ModuleNotFoundError("h5py"))
+sys.modules.setdefault("nibabel", types.ModuleType("nibabel"))
+class _Img:
+    def agg_data(self):
+        return []
+sys.modules["nibabel"].load = lambda *a, **k: _Img()
+sys.modules.setdefault("matplotlib", types.ModuleType("matplotlib"))
+sys.modules.setdefault("matplotlib.pyplot", types.ModuleType("matplotlib.pyplot"))
+sys.modules.setdefault("vtk", types.ModuleType("vtk"))
+sys.modules.setdefault("spm_standalone", types.ModuleType("spm_standalone"))
+sys.modules.setdefault("scipy.io", types.ModuleType("scipy.io"))
+sys.modules["scipy.io"].savemat = lambda *a, **k: None
+sys.modules["scipy.io"].loadmat = lambda *a, **k: {}
+sys.modules.setdefault("scipy.spatial", types.ModuleType("scipy.spatial"))
+sys.modules["scipy.spatial"].KDTree = object
+sys.modules.setdefault("scipy.stats", types.ModuleType("scipy.stats"))
+sys.modules["scipy.stats"].t = object
+
+# Import util module without triggering heavy package imports
+spec = importlib.util.spec_from_file_location(
+    "util", Path(__file__).parent / "lameg" / "util.py"
+)
+util = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(util)
+
+check_many = util.check_many
+get_files = util.get_files
+
+
+def test_get_files_without_strings(tmp_path):
+    (tmp_path / 'a.txt').write_text('')
+    (tmp_path / 'b.txt').write_text('')
+    files_any = get_files(tmp_path, '*.txt', check='any')
+    files_all = get_files(tmp_path, '*.txt')
+    assert len(files_any) == 2
+    assert len(files_all) == 2
+    assert check_many([], 'anything', 'any')
+    assert check_many([], 'anything', 'all')


### PR DESCRIPTION
## Summary
- Treat missing string lists as a no-op in `check_many`
- Allow `get_files`/`get_directories` to accept `None` for string filters
- Add regression test for empty string handling

## Testing
- `pytest test_check_many.py -q`
- `pytest -q` *(fails: No module named 'spm_standalone')*

------
https://chatgpt.com/codex/tasks/task_e_6899ac994d348321abcc5435dcd51e44